### PR TITLE
Add Excel formatter using pandas and improve export

### DIFF
--- a/utils/excel_formatter.py
+++ b/utils/excel_formatter.py
@@ -1,0 +1,46 @@
+"""Utilities to format raw Excel exports into ConstrucData format."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+
+from .construcdata_parser import parse_rows
+from .excel_handler import export_to_excel
+
+
+def _load_rows_from_excel(input_path: str) -> List[List[str]]:
+    """Load *input_path* and return its contents as a list of string rows.
+
+    The function uses :func:`pandas.read_excel` without header assumption and
+    fills missing values with empty strings so that the parser can operate on
+    uniform data.
+    """
+
+    df = pd.read_excel(input_path, header=None).fillna("")
+    return df.astype(str).values.tolist()
+
+
+def format_to_construcdata(input_path: str, output_path: str) -> None:
+    """Convert *input_path* Excel file to ConstrucData format.
+
+    The source Excel is parsed using the existing card parser and the resulting
+    structured data is exported through :func:`export_to_excel`.
+    """
+
+    rows = _load_rows_from_excel(input_path)
+    cards = parse_rows(rows)
+
+    data = [
+        [
+            card.get("clave", ""),
+            card.get("descripcion", ""),
+            card.get("unidad", ""),
+            card.get("jornada", ""),
+            card.get("rendimiento", ""),
+        ]
+        for card in cards
+    ]
+    resources = [card.get("recursos", []) for card in cards]
+    export_to_excel(data, resources, output_path)

--- a/utils/excel_handler.py
+++ b/utils/excel_handler.py
@@ -9,17 +9,25 @@ def export_to_excel(data, resources, output_path):
             representar una fila con los campos "Clave", "Descripción",
             "Unidad", "Jornada" y "Rendimiento".
         resources (list): Lista de objetos que representan los
-            insumos o recursos asociados. Se serializa a JSON para su
-            almacenamiento en la columna "Insumos/Recursos".
+            insumos o recursos asociados. Puede ser una única lista de recursos
+            o una lista de listas para asociar recursos a cada fila.
         output_path (str): Ruta del archivo de salida.
     """
 
-    df = pd.DataFrame(data, columns=[
-        "Clave",
-        "Descripción",
-        "Unidad",
-        "Jornada",
-        "Rendimiento",
-    ])
-    df["Insumos/Recursos"] = json.dumps(resources, ensure_ascii=False)
+    df = pd.DataFrame(
+        data,
+        columns=[
+            "Clave",
+            "Descripción",
+            "Unidad",
+            "Jornada",
+            "Rendimiento",
+        ],
+    )
+
+    if len(resources) == len(data) and not isinstance(resources, (str, bytes)):
+        df["Insumos/Recursos"] = [json.dumps(r, ensure_ascii=False) for r in resources]
+    else:
+        df["Insumos/Recursos"] = json.dumps(resources, ensure_ascii=False)
+
     df.to_excel(output_path, index=False)


### PR DESCRIPTION
## Summary
- add Excel formatter utility that reads sheets with pandas, parses ConstrucData cards and exports via existing handler
- extend Excel exporter to support per-row resource lists

## Testing
- `python -m py_compile utils/excel_formatter.py utils/excel_handler.py utils/construcdata_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68a21a50b3a0832faf49afef09798981