### PR TITLE
Corrige mapeo de columnas de recursos y claves JSON

### DIFF
--- a/utils/construcdata_parser.py
+++ b/utils/construcdata_parser.py
@@ -35,24 +35,30 @@ def _parse_resource(row: List[str]) -> Dict[str, str]:
     The number of columns in the raw data may vary; this function tries to
     map the most common five-column layout:
     ``clave``, ``descripcion``, ``unidad``, ``cantidad`` and ``precio``.
-    Any missing fields are filled with an empty string.
+    Any ``importe`` column present in the source is ignored.
+    Missing fields are filled with an empty string.
     """
 
-    if len(row) > 4:
-        descripcion = " ".join(row[1:-3]).strip()
-    elif len(row) > 2:
-        descripcion = " ".join(row[1:-2]).strip()
-    elif len(row) > 1:
-        descripcion = row[1].strip()
+    # Remove trailing "importe" column if present.
+    cleaned = [cell.strip() for cell in row]
+    if len(cleaned) > 5:
+        cleaned = cleaned[:5]
+
+    if len(cleaned) > 4:
+        descripcion = " ".join(cleaned[1:-3]).strip()
+    elif len(cleaned) > 2:
+        descripcion = " ".join(cleaned[1:-2]).strip()
+    elif len(cleaned) > 1:
+        descripcion = cleaned[1].strip()
     else:
         descripcion = ""
 
     recurso: Dict[str, str] = {
-        "clave": row[0].strip() if row else "",
+        "clave": cleaned[0] if cleaned else "",
         "descripcion": descripcion,
-        "unidad": row[-3].strip() if len(row) >= 3 else "",
-        "cantidad": row[-2].strip() if len(row) >= 2 else "",
-        "precio": row[-1].strip() if row else "",
+        "unidad": cleaned[-3] if len(cleaned) >= 3 else "",
+        "cantidad": cleaned[-2] if len(cleaned) >= 2 else "",
+        "precio": cleaned[-1] if cleaned else "",
     }
     return recurso
 

--- a/utils/excel_handler.py
+++ b/utils/excel_handler.py
@@ -25,9 +25,23 @@ def export_to_excel(data, resources, output_path):
         ],
     )
 
+    def _map_resource(res):
+        return {
+            "Clave": res.get("clave", ""),
+            "Descripción": res.get("descripcion", ""),
+            "Unidad": res.get("unidad", ""),
+            "Cantidad": res.get("cantidad", ""),
+            "Costo": res.get("precio", ""),
+        }
+
     if len(resources) == len(data) and not isinstance(resources, (str, bytes)):
-        df["Insumos/Recursos"] = [json.dumps(r, ensure_ascii=False) for r in resources]
+        df["Insumos/Recursos"] = [
+            json.dumps([_map_resource(r) for r in row], ensure_ascii=False)
+            for row in resources
+        ]
     else:
-        df["Insumos/Recursos"] = json.dumps(resources, ensure_ascii=False)
+        df["Insumos/Recursos"] = json.dumps(
+            [_map_resource(r) for r in resources], ensure_ascii=False
+        )
 
     df.to_excel(output_path, index=False)


### PR DESCRIPTION
## Summary
- Ignora la columna de importe al interpretar recursos de Excel para evitar desalineaciones
- Renombra los campos de recursos en el JSON generado (`Clave`, `Descripción`, `Unidad`, `Cantidad`, `Costo`)

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from utils.excel_handler import export_to_excel
import pandas as pd, os

data = [["A","desc","m2","8","10"]]
resources = [[{"clave":"MAT1","descripcion":"Arena","unidad":"m3","cantidad":"2","precio":"100"}]]
export_to_excel(data, resources, "test_output.xlsx")
print(pd.read_excel("test_output.xlsx")["Insumos/Recursos"][0])
os.remove("test_output.xlsx")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a238d7b168832fbaaecf2dec03b171